### PR TITLE
Updating dev/voliro branch 

### DIFF
--- a/modules/ipc/include/hephaestus/ipc/zenoh/liveliness.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/liveliness.h
@@ -75,7 +75,7 @@ private:
 
   std::unique_ptr<::zenoh::Subscriber<void>> liveliness_subscriber_;
 
-  static constexpr std::size_t DEFAULT_CACHE_RESERVES = 100;
+  static constexpr std::size_t DEFAULT_CACHE_RESERVES = 1000;
   std::unique_ptr<concurrency::MessageQueueConsumer<EndpointInfo>> infos_consumer_;
 };
 

--- a/modules/ipc/include/hephaestus/ipc/zenoh/raw_subscriber.h
+++ b/modules/ipc/include/hephaestus/ipc/zenoh/raw_subscriber.h
@@ -75,7 +75,7 @@ private:
   std::unique_ptr<Service<std::string, std::string>> type_service_;
 
   bool dedicated_callback_thread_;
-  static constexpr std::size_t DEFAULT_CACHE_RESERVES = 100;
+  static constexpr std::size_t DEFAULT_CACHE_RESERVES = 1000;
   std::unique_ptr<concurrency::MessageQueueConsumer<Message>> callback_messages_consumer_;
 };
 

--- a/modules/ipc/src/zenoh/dynamic_subscriber.cpp
+++ b/modules/ipc/src/zenoh/dynamic_subscriber.cpp
@@ -91,8 +91,7 @@ void DynamicSubscriber::onPublisherAdded(const EndpointInfo& info) {
   heph::log(heph::DEBUG, "create subscriber", "topic", info.topic);
   subscribers_[info.topic] = std::make_unique<ipc::zenoh::RawSubscriber>(
       session_, ipc::TopicConfig{ info.topic },
-      [this, type_info = std::move(*type_info)](const MessageMetadata& metadata,
-                                                std::span<const std::byte> data) {
+      [this, type_info = *type_info](const MessageMetadata& metadata, std::span<const std::byte> data) {
         subscriber_cb_(metadata, data, type_info);
       },
       *type_info);

--- a/modules/ipc/src/zenoh/liveliness.cpp
+++ b/modules/ipc/src/zenoh/liveliness.cpp
@@ -185,12 +185,10 @@ void EndpointDiscovery::createLivelinessSubscriber() {
   auto liveliness_callback = [this](const ::zenoh::Sample& sample) mutable {
     auto info = parseLivelinessToken(sample.get_keyexpr().as_string_view(), sample.get_kind());
     if (info.has_value()) {
-      auto dropped_element = infos_consumer_->queue().forcePush(std::move(*info));
-      if (dropped_element.has_value()) {
-        heph::log(heph::ERROR,
-                  "Dropped endpoint discovery info before being able to process due to full queue",
-                  "dropped_info", fmt::to_string(dropped_element.value()));
-      }
+      const auto dropped_element = infos_consumer_->queue().forcePush(std::move(*info));
+      logIf(heph::ERROR, dropped_element.has_value(),
+            "Dropped endpoint discovery info before being able to process due to full queue",
+            "dropped_endpoint_info_topic", dropped_element.value().topic);
     } else {
       heph::log(heph::ERROR, "failed to parse liveliness token", "keyexpr",
                 sample.get_keyexpr().as_string_view(), "kind", magic_enum::enum_name(sample.get_kind()));

--- a/modules/ipc/src/zenoh/liveliness.cpp
+++ b/modules/ipc/src/zenoh/liveliness.cpp
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 #include <magic_enum.hpp>
 #include <zenoh.h>
+#include <zenoh/api/base.hxx>
 #include <zenoh/api/channels.hxx>
 #include <zenoh/api/closures.hxx>
 #include <zenoh/api/enums.hxx>
@@ -32,6 +33,7 @@
 #include "hephaestus/ipc/zenoh/conversions.h"
 #include "hephaestus/ipc/zenoh/session.h"
 #include "hephaestus/telemetry/log.h"
+#include "hephaestus/utils/exception.h"
 
 namespace heph::ipc::zenoh {
 namespace {
@@ -200,13 +202,12 @@ void EndpointDiscovery::createLivelinessSubscriber() {
     }
   };
 
-  ::zenoh::Session::LivelinessSubscriberOptions options {
-    .history = true,
-  };
-
+  ::zenoh::ZResult result{};
   liveliness_subscriber_ =
       std::make_unique<::zenoh::Subscriber<void>>(session_->zenoh_session.liveliness_declare_subscriber(
-          keyexpr, std::move(liveliness_callback), ::zenoh::closures::none, std::move(options)));
+          keyexpr, std::move(liveliness_callback), ::zenoh::closures::none, { .history = true }, &result));
+  panicIf(result != Z_OK, "[Liveliness Subscriber '**'] failed to create liveliness subscriber, err {}",
+          result);
 }
 
 }  // namespace heph::ipc::zenoh

--- a/modules/ipc/src/zenoh/liveliness.cpp
+++ b/modules/ipc/src/zenoh/liveliness.cpp
@@ -163,20 +163,7 @@ EndpointDiscovery::EndpointDiscovery(SessionPtr session, TopicConfig topic_confi
   , infos_consumer_(std::make_unique<concurrency::MessageQueueConsumer<EndpointInfo>>(
         [this](const EndpointInfo& info) { callback_(info); }, DEFAULT_CACHE_RESERVES)) {
   infos_consumer_->start();
-  // NOTE: the liveliness token subscriber is called only when the status of the publisher changes.
-  // This means that we won't get the list of publisher that are already running.
-  // To do that we need to query the list of publisher beforehand.
-  auto publishers_info = getListOfEndpoints(*session_, topic_config_.name);
-  for (const auto& info : publishers_info) {
-    infos_consumer_->queue().forcePush(info);
-  }
 
-  // Here we create the subscriber for the liveliness tokens.
-  // NOTE: If a publisher start publishing between the previous call and the time needed to start the
-  // subscriber, we will loose that publisher.
-  // This could be avoided by querying for the list of publisher after we start the subscriber and keeping a
-  // track of what we already advertised so not to call the user callback twice on the same event.
-  // TODO: implement the optimization described above.
   createLivelinessSubscriber();
 }
 

--- a/modules/ipc/src/zenoh/liveliness.cpp
+++ b/modules/ipc/src/zenoh/liveliness.cpp
@@ -185,7 +185,15 @@ void EndpointDiscovery::createLivelinessSubscriber() {
   auto liveliness_callback = [this](const ::zenoh::Sample& sample) mutable {
     auto info = parseLivelinessToken(sample.get_keyexpr().as_string_view(), sample.get_kind());
     if (info.has_value()) {
-      infos_consumer_->queue().forcePush(std::move(*info));
+      auto dropped_element = infos_consumer_->queue().forcePush(std::move(*info));
+      if (dropped_element.has_value()) {
+        heph::log(heph::ERROR,
+                  "Dropped endpoint discovery info before being able to process due to full queue",
+                  "dropped_info", fmt::to_string(dropped_element.value()));
+      }
+    } else {
+      heph::log(heph::ERROR, "failed to parse liveliness token", "keyexpr",
+                sample.get_keyexpr().as_string_view(), "kind", magic_enum::enum_name(sample.get_kind()));
     }
   };
 
@@ -193,8 +201,7 @@ void EndpointDiscovery::createLivelinessSubscriber() {
   liveliness_subscriber_ =
       std::make_unique<::zenoh::Subscriber<void>>(session_->zenoh_session.liveliness_declare_subscriber(
           keyexpr, std::move(liveliness_callback), ::zenoh::closures::none, { .history = true }, &result));
-  panicIf(result != Z_OK, "[Liveliness Subscriber '**'] failed to create liveliness subscriber, err {}",
-          result);
+  panicIf(result != Z_OK, "[Liveliness Subscriber '**'] failed to create liveliness subscriber");
 }
 
 }  // namespace heph::ipc::zenoh

--- a/modules/ipc/src/zenoh/liveliness.cpp
+++ b/modules/ipc/src/zenoh/liveliness.cpp
@@ -200,9 +200,13 @@ void EndpointDiscovery::createLivelinessSubscriber() {
     }
   };
 
+  ::zenoh::Session::LivelinessSubscriberOptions options {
+    .history = true,
+  };
+
   liveliness_subscriber_ =
       std::make_unique<::zenoh::Subscriber<void>>(session_->zenoh_session.liveliness_declare_subscriber(
-          keyexpr, std::move(liveliness_callback), ::zenoh::closures::none));
+          keyexpr, std::move(liveliness_callback), ::zenoh::closures::none, std::move(options)));
 }
 
 }  // namespace heph::ipc::zenoh

--- a/modules/ipc/src/zenoh/raw_publisher.cpp
+++ b/modules/ipc/src/zenoh/raw_publisher.cpp
@@ -100,9 +100,23 @@ void RawPublisher::createTypeInfoService() {
     (void)request;
     return type_info_json;
   };
-  auto type_service_topic = TopicConfig{ getEndpointTypeInfoServiceTopic(topic_config_.name) };
-  type_service_ = std::make_unique<Service<std::string, std::string>>(session_, type_service_topic,
-                                                                      std::move(type_info_callback));
+
+  auto failure_callback = [topic_name = topic_config_.name]() {
+    heph::log(heph::ERROR, "Failed to process type info service", "topic", topic_name);
+  };
+  
+  auto post_reply_callback = []() {
+    // Do nothing.
+  };
+
+  ServiceConfig service_config = {
+    .create_liveliness_token = false,
+    .create_type_info_service = false,
+  };
+
+  type_service_ = std::make_unique<Service<std::string, std::string>>(
+      session_, TopicConfig{ getEndpointTypeInfoServiceTopic(topic_config_.name) },
+      std::move(type_info_callback), failure_callback, post_reply_callback, service_config);
 }
 
 void RawPublisher::initializeAttachment() {

--- a/modules/ipc/src/zenoh/raw_publisher.cpp
+++ b/modules/ipc/src/zenoh/raw_publisher.cpp
@@ -104,12 +104,12 @@ void RawPublisher::createTypeInfoService() {
   auto failure_callback = [topic_name = topic_config_.name]() {
     heph::log(heph::ERROR, "Failed to process type info service", "topic", topic_name);
   };
-  
+
   auto post_reply_callback = []() {
     // Do nothing.
   };
 
-  ServiceConfig service_config = {
+  const ServiceConfig service_config = {
     .create_liveliness_token = false,
     .create_type_info_service = false,
   };

--- a/modules/ipc/src/zenoh/raw_subscriber.cpp
+++ b/modules/ipc/src/zenoh/raw_subscriber.cpp
@@ -148,9 +148,23 @@ void RawSubscriber::createTypeInfoService() {
     (void)request;
     return type_info_json;
   };
-  auto type_service_topic = TopicConfig{ getEndpointTypeInfoServiceTopic(topic_config_.name) };
-  type_service_ = std::make_unique<Service<std::string, std::string>>(session_, type_service_topic,
-                                                                      std::move(type_info_callback));
+
+  auto failure_callback = [topic_name = topic_config_.name]() {
+    heph::log(heph::ERROR, "Failed to process type info service", "topic", topic_name);
+  };
+
+  auto post_reply_callback = []() {
+    // Do nothing.
+  };
+
+  ServiceConfig service_config = {
+    .create_liveliness_token = false,
+    .create_type_info_service = false,
+  };
+
+  type_service_ = std::make_unique<Service<std::string, std::string>>(
+      session_, TopicConfig{ getEndpointTypeInfoServiceTopic(topic_config_.name) },
+      std::move(type_info_callback), failure_callback, post_reply_callback, service_config);
 }
 
 }  // namespace heph::ipc::zenoh

--- a/modules/ipc/src/zenoh/raw_subscriber.cpp
+++ b/modules/ipc/src/zenoh/raw_subscriber.cpp
@@ -73,7 +73,12 @@ RawSubscriber::RawSubscriber(SessionPtr session, TopicConfig topic_config, DataC
   , type_info_(std::move(type_info))
   , dedicated_callback_thread_(config.dedicated_callback_thread) {
   if (config.create_type_info_service) {
-    createTypeInfoService();
+    if (type_info_.isValid()) {
+      createTypeInfoService();
+    } else {
+      heph::log(heph::ERROR, "Cannot offer type info service for sub with invalid type info.", "topic",
+                topic_config_.name, "type_info", type_info_.toJson());
+    }
   }
 
   auto sub_options = ::zenoh::ext::SessionExt::AdvancedSubscriberOptions::create_default();

--- a/modules/ipc/src/zenoh/raw_subscriber.cpp
+++ b/modules/ipc/src/zenoh/raw_subscriber.cpp
@@ -137,9 +137,8 @@ void RawSubscriber::callback(const ::zenoh::Sample& sample) {
 
   if (dedicated_callback_thread_) {
     auto dropped_element = callback_messages_consumer_->queue().forceEmplace(metadata, std::move(payload));
-    if (dropped_element.has_value()) {
-      heph::log(heph::ERROR, "Dropped subscriber message due to full queue", "topic", topic_config_.name);
-    }
+    logIf(heph::ERROR, dropped_element.has_value(), "Dropped subscriber message due to full queue", "topic",
+          topic_config_.name);
   } else {
     callback_(metadata, { payload.data(), payload.size() });
   }

--- a/modules/ipc/src/zenoh/raw_subscriber.cpp
+++ b/modules/ipc/src/zenoh/raw_subscriber.cpp
@@ -136,7 +136,10 @@ void RawSubscriber::callback(const ::zenoh::Sample& sample) {
   auto payload = toByteVector(sample.get_payload());
 
   if (dedicated_callback_thread_) {
-    callback_messages_consumer_->queue().forceEmplace(metadata, std::move(payload));
+    auto dropped_element = callback_messages_consumer_->queue().forceEmplace(metadata, std::move(payload));
+    if (dropped_element.has_value()) {
+      heph::log(heph::ERROR, "Dropped subscriber message due to full queue", "topic", topic_config_.name);
+    }
   } else {
     callback_(metadata, { payload.data(), payload.size() });
   }

--- a/modules/ipc/src/zenoh/raw_subscriber.cpp
+++ b/modules/ipc/src/zenoh/raw_subscriber.cpp
@@ -157,7 +157,7 @@ void RawSubscriber::createTypeInfoService() {
     // Do nothing.
   };
 
-  ServiceConfig service_config = {
+  const ServiceConfig service_config = {
     .create_liveliness_token = false,
     .create_type_info_service = false,
   };

--- a/modules/ipc/src/zenoh/topic_database.cpp
+++ b/modules/ipc/src/zenoh/topic_database.cpp
@@ -58,10 +58,8 @@ auto ZenohTopicDatabase::getTypeInfo(const std::string& topic) -> std::optional<
   const auto response =
       zenoh::callService<std::string, std::string>(*session_, TopicConfig{ query_topic }, "", TIMEOUT);
 
-  if (response.size() > 1) {
-    heph::log(heph::WARN, "received multiple type info responses for service", "responses", response.size(),
-              "topic", topic, "query_topic", query_topic);
-  }
+  heph::logIf(heph::WARN, response.size() > 1, "received multiple type info responses for topic", "responses",
+              response.size(), "topic", topic, "query_topic", query_topic);
 
   const absl::MutexLock lock{ &topic_mutex_ };
   // While waiting for the query someone else could have added the topic type to the DB.
@@ -93,10 +91,8 @@ auto ZenohTopicDatabase::getTypeInfo(const std::string& topic) -> std::optional<
   const auto response =
       zenoh::callService<std::string, std::string>(*session_, TopicConfig{ query_topic }, "", TIMEOUT);
 
-  if (response.size() > 1) {
-    heph::log(heph::WARN, "received multiple service type info responses for service", "responses",
-              response.size(), "service", topic, "query_topic", query_topic);
-  }
+  heph::logIf(heph::WARN, response.size() > 1, "received multiple type info responses for service",
+              "responses", response.size(), "service", topic, "query_topic", query_topic);
 
   const absl::MutexLock lock{ &service_mutex_ };
   // While waiting for the query someone else could have added the service type to the DB.

--- a/modules/ipc/src/zenoh/topic_database.cpp
+++ b/modules/ipc/src/zenoh/topic_database.cpp
@@ -58,19 +58,20 @@ auto ZenohTopicDatabase::getTypeInfo(const std::string& topic) -> std::optional<
   const auto response =
       zenoh::callService<std::string, std::string>(*session_, TopicConfig{ query_topic }, "", TIMEOUT);
 
-  if (response.empty()) {
-    heph::log(heph::ERROR, "failed to get type info, no response from service", "topic", topic);
-    return std::nullopt;
-  }
-
   if (response.size() > 1) {
     heph::log(heph::WARN, "received multiple type info responses for service", "responses", response.size(),
               "topic", topic, "query_topic", query_topic);
   }
 
   const absl::MutexLock lock{ &topic_mutex_ };
-  // While waiting for the query someone else could have added the topic to the DB.
-  if (!topics_type_db_.contains(topic)) {
+  // While waiting for the query someone else could have added the topic type to the DB.
+  const bool already_in_db = topics_type_db_.contains(topic);
+  if (!already_in_db) {
+    if (response.empty()) {
+      heph::log(heph::ERROR, "failed to get type info, no response from service", "topic", topic);
+      return std::nullopt;
+    }
+
     topics_type_db_[topic] = serdes::TypeInfo::fromJson(response.front().value);
   }
 
@@ -91,14 +92,21 @@ auto ZenohTopicDatabase::getTypeInfo(const std::string& topic) -> std::optional<
   static constexpr auto TIMEOUT = std::chrono::milliseconds{ 5000 };
   const auto response =
       zenoh::callService<std::string, std::string>(*session_, TopicConfig{ query_topic }, "", TIMEOUT);
-  if (response.empty()) {
-    heph::log(heph::ERROR, "failed to get type info, no response from service", "topic", topic);
-    return std::nullopt;
+
+  if (response.size() > 1) {
+    heph::log(heph::WARN, "received multiple service type info responses for service", "responses",
+              response.size(), "service", topic, "query_topic", query_topic);
   }
 
   const absl::MutexLock lock{ &service_mutex_ };
-  // While waiting for the query someone else could have added the topic to the DB.
-  if (!service_topics_type_db_.contains(topic)) {
+  // While waiting for the query someone else could have added the service type to the DB.
+  const bool already_in_db = service_topics_type_db_.contains(topic);
+  if (!already_in_db) {
+    if (response.empty()) {
+      heph::log(heph::ERROR, "failed to get service type info, no response from service", "service", topic);
+      return std::nullopt;
+    }
+
     service_topics_type_db_[topic] = serdes::ServiceTypeInfo::fromJson(response.front().value);
   }
 

--- a/modules/serdes/include/hephaestus/serdes/type_info.h
+++ b/modules/serdes/include/hephaestus/serdes/type_info.h
@@ -22,6 +22,7 @@ struct TypeInfo {
 
   [[nodiscard]] auto toJson() const -> std::string;
   [[nodiscard]] static auto fromJson(const std::string& info) -> TypeInfo;
+  [[nodiscard]] auto isValid() const -> bool;
   [[nodiscard]] auto operator==(const TypeInfo&) const -> bool = default;
 };
 
@@ -31,6 +32,7 @@ struct ServiceTypeInfo {
 
   [[nodiscard]] auto toJson() const -> std::string;
   [[nodiscard]] static auto fromJson(const std::string& info) -> ServiceTypeInfo;
+  [[nodiscard]] auto isValid() const -> bool;
   [[nodiscard]] auto operator==(const ServiceTypeInfo&) const -> bool = default;
 };
 

--- a/modules/serdes/src/type_info.cpp
+++ b/modules/serdes/src/type_info.cpp
@@ -38,6 +38,22 @@ auto TypeInfo::fromJson(const std::string& info) -> TypeInfo {
            .original_type = data["original_type"] };
 }
 
+auto TypeInfo::isValid() const -> bool {
+  switch (serialization) {
+    case Serialization::TEXT:
+    case Serialization::JSON:
+      // For TEXT and JSON, no additional information is technically required.
+      return true;
+    case Serialization::PROTOBUF:
+      // For PROTOBUF, name and schema must not be empty.
+      // The schema should also be a valid protobuf definition, but we will not check that here.
+      return !schema.empty() && !name.empty();
+    default:
+      panic(fmt::format("unknown serialization type: {}", magic_enum::enum_name(serialization)));
+  }
+  return false;
+}
+
 auto ServiceTypeInfo::toJson() const -> std::string {
   nlohmann::json data;
   data["request"] = nlohmann::json::parse(request.toJson());
@@ -50,5 +66,9 @@ auto ServiceTypeInfo::fromJson(const std::string& info) -> ServiceTypeInfo {
   auto data = nlohmann::json::parse(info);
   return { .request = TypeInfo::fromJson(data["request"].dump()),
            .reply = TypeInfo::fromJson(data["reply"].dump()) };
+}
+
+auto ServiceTypeInfo::isValid() const -> bool {
+  return request.isValid() && reply.isValid();
 }
 }  // namespace heph::serdes

--- a/modules/serdes/src/type_info.cpp
+++ b/modules/serdes/src/type_info.cpp
@@ -48,8 +48,6 @@ auto TypeInfo::isValid() const -> bool {
       // For PROTOBUF, name and schema must not be empty.
       // The schema should also be a valid protobuf definition, but we will not check that here.
       return !schema.empty() && !name.empty();
-    default:
-      panic(fmt::format("unknown serialization type: {}", magic_enum::enum_name(serialization)));
   }
   return false;
 }

--- a/modules/telemetry/telemetry/include/hephaestus/telemetry/log_sink.h
+++ b/modules/telemetry/telemetry/include/hephaestus/telemetry/log_sink.h
@@ -26,7 +26,7 @@
 namespace heph {
 ///@brief Forward declaration of LogLevel. Definition is in log.h, since we only want to include that when
 /// logging.
-enum LogLevel : std::uint8_t { TRACE, DEBUG, INFO, WARN, ERROR, FATAL };
+enum LogLevel : std::uint8_t { VERBOSE, TRACE, DEBUG, INFO, WARN, ERROR, FATAL };
 }  // namespace heph
 
 namespace heph::telemetry {

--- a/modules/telemetry/telemetry/src/log_sinks/absl_sink.cpp
+++ b/modules/telemetry/telemetry/src/log_sinks/absl_sink.cpp
@@ -18,6 +18,9 @@ namespace heph::telemetry {
 AbslLogSink::AbslLogSink(LogLevel log_level)
   : formatter_([](const LogEntry& l) { return fmt::format("{}", l); }) {
   switch (log_level) {
+    case LogLevel::VERBOSE:
+      // Don't set the global vlog level but use the one from --v in the command line
+      break;
     case LogLevel::TRACE:
       absl::SetGlobalVLogLevel(2);
       break;

--- a/modules/websocket_bridge/config/ws_bridge-config.yaml
+++ b/modules/websocket_bridge/config/ws_bridge-config.yaml
@@ -26,6 +26,7 @@ ws_server_port: 8765
 ws_server_address: 0.0.0.0
 ws_server_verbose_bridge_state: true
 ws_server_verbose_ipc_graph_state: true
+
 zenoh_config:
   use_binary_name_as_session_id: false
   id: "ws_bridge"

--- a/modules/websocket_bridge/config/ws_bridge-config.yaml
+++ b/modules/websocket_bridge/config/ws_bridge-config.yaml
@@ -30,7 +30,7 @@ zenoh_config:
   # zenoh_config_path: ""
   enable_shared_memory: false
   mode: PEER
-  router: "127.0.01:7447"
+  router: "127.0.0.1:7447"
   qos: false
   real_time: false
   protocol: ANY

--- a/modules/websocket_bridge/config/ws_bridge-config.yaml
+++ b/modules/websocket_bridge/config/ws_bridge-config.yaml
@@ -24,6 +24,8 @@ ws_server_port: 8765
 # - 0.0.0.0 -> bridge visible on all interfaces, e.g. for local LAN access
 # - localhost or 127.0.0.1 -> bridge only accessible from within this machine
 ws_server_address: 0.0.0.0
+ws_server_verbose_bridge_state: true
+ws_server_verbose_ipc_graph_state: true
 zenoh_config:
   use_binary_name_as_session_id: false
   id: "ws_bridge"

--- a/modules/websocket_bridge/include/hephaestus/websocket_bridge/bridge_config.h
+++ b/modules/websocket_bridge/include/hephaestus/websocket_bridge/bridge_config.h
@@ -59,6 +59,10 @@ struct WebsocketBridgeConfig {
   uint16_t ws_server_port = DEFAULT_WS_SERVER_PORT;
   std::string ws_server_address = "0.0.0.0";
 
+  // If enabled, the bridge will print the full state every time it changes.
+  bool ws_server_verbose_bridge_state = false;
+  bool ws_server_verbose_ipc_graph_state = false;
+
   /////////
   // IPC //
   /////////

--- a/modules/websocket_bridge/src/websocket_bridge/bridge.cpp
+++ b/modules/websocket_bridge/src/websocket_bridge/bridge.cpp
@@ -194,7 +194,9 @@ void WebsocketBridge::callback_IpcGraph_TopicFound(const std::string& topic,
             type_info.name);
 
   if (state_.hasIpcTopicMapping(topic)) {
-    state_.printBridgeState();
+    if (config_.ws_server_verbose_bridge_state) {
+      state_.printBridgeState();
+    }
     heph::log(
         heph::WARN,
         fmt::format("\n[WS Bridge] - Topic is already advertized! There are likely multiple publishers!",
@@ -218,7 +220,9 @@ void WebsocketBridge::callback_IpcGraph_TopicFound(const std::string& topic,
 void WebsocketBridge::callback_IpcGraph_TopicDropped(const std::string& topic) {
   heph::log(heph::INFO, "[WS Bridge] - Topic will be dropped  ...", "topic", topic);
   if (!state_.hasIpcTopicMapping(topic)) {
-    state_.printBridgeState();
+    if (config_.ws_server_verbose_bridge_state) {
+      state_.printBridgeState();
+    }
     heph::log(
         heph::WARN,
         fmt::format("\n[WS Bridge] - Topic is already unadvertized! There are likely multiple publishers!",
@@ -289,7 +293,9 @@ void WebsocketBridge::callback_IpcGraph_ServiceDropped(const std::string& servic
   heph::log(heph::INFO, "[WS Bridge] - Service will be dropped  ...", "service_name", service_name);
 
   if (!state_.hasIpcServiceMapping(service_name)) {
-    state_.printBridgeState();
+    if (config_.ws_server_verbose_bridge_state) {
+      state_.printBridgeState();
+    }
     heph::log(
         heph::WARN,
         fmt::format(
@@ -313,10 +319,14 @@ void WebsocketBridge::callback_IpcGraph_Updated(const ipc::zenoh::EndpointInfo& 
   // it.
   (void)info;
 
-  ipc_graph_state.printIpcGraphState();
+  if (config_.ws_server_verbose_ipc_graph_state) {
+    ipc_graph_state.printIpcGraphState();
+  }
   CHECK(ipc_graph_state.checkConsistency());
 
-  state_.printBridgeState();
+  if (config_.ws_server_verbose_bridge_state) {
+    state_.printBridgeState();
+  }
   CHECK(state_.checkConsistency());
 
   foxglove::MapOfSets topic_to_pub_node_map;
@@ -534,8 +544,9 @@ void WebsocketBridge::callback_Ws_Subscribe(WsChannelId channel_id, const WsClie
 
   heph::log(heph::INFO, "[WS Bridge] - Client subcribed to topic successfully. [IPC SUB ADDED]",
             "client_name", client_name, "topic", topic, "channel_id", channel_id);
-
-  state_.printBridgeState();
+  if (config_.ws_server_verbose_bridge_state) {
+    state_.printBridgeState();
+  }
 }
 
 void WebsocketBridge::callback_Ws_Unsubscribe(WsChannelId channel_id, const WsClientHandle& client_handle) {
@@ -565,8 +576,9 @@ void WebsocketBridge::callback_Ws_Unsubscribe(WsChannelId channel_id, const WsCl
               "\n[WS Bridge] - Client unsubscribed from topic successfully. [IPC SUB STILL NEEDED]",
               "client_name", client_name, "topic", topic, "channel_id", channel_id);
   }
-
-  state_.printBridgeState();
+  if (config_.ws_server_verbose_bridge_state) {
+    state_.printBridgeState();
+  }
 }
 
 void WebsocketBridge::callback_Ws_ClientAdvertise(const WsClientChannelAd& advertisement,
@@ -616,7 +628,9 @@ void WebsocketBridge::callback_Ws_ClientAdvertise(const WsClientChannelAd& adver
               "client_name", client_name, "topic", topic, "channel_id", channel_id);
   }
 
-  state_.printBridgeState();
+  if (config_.ws_server_verbose_bridge_state) {
+    state_.printBridgeState();
+  }
 }
 
 void WebsocketBridge::callback_Ws_ClientUnadvertise(WsClientChannelId client_channel_id,
@@ -660,7 +674,9 @@ void WebsocketBridge::callback_Ws_ClientUnadvertise(WsClientChannelId client_cha
               "client_name", client_name, "topic", topic, "client_channel_id", client_channel_id);
   }
 
-  state_.printBridgeState();
+  if (config_.ws_server_verbose_bridge_state) {
+    state_.printBridgeState();
+  }
 }
 
 void WebsocketBridge::callback_Ws_ClientMessage(const WsClientMessage& message,

--- a/modules/websocket_bridge/src/websocket_bridge/bridge.cpp
+++ b/modules/websocket_bridge/src/websocket_bridge/bridge.cpp
@@ -457,7 +457,7 @@ void WebsocketBridge::callback_Ipc_ServiceResponsesReceived(
   const auto client_handle = client_handle_w_name.first;
 
   if (responses.empty()) {
-    auto msg = "[WS Bridge] - Timeout - no service responses received.";
+    const auto* msg = "[WS Bridge] - Timeout - no service responses received.";
     heph::log(heph::ERROR, msg, "service_name", service_name, "service_id", service_id, "call_id", call_id);
     ws_server_->sendServiceFailure(client_handle, service_id, call_id, msg);
     return;
@@ -470,7 +470,7 @@ void WebsocketBridge::callback_Ipc_ServiceResponsesReceived(
 
   const auto& response = responses.front();
   if (response.topic != service_name) {
-    auto msg = "[WS Bridge] - Response and request names do not match!";
+    const auto* msg = "[WS Bridge] - Response and request names do not match!";
     heph::log(heph::ERROR, msg, "service_id", service_id, "call_id", call_id, "response_topic",
               response.topic, "service_name", service_name, "service_name_in_response", response.topic);
     ws_server_->sendServiceFailure(client_handle, service_id, call_id, msg);
@@ -479,7 +479,8 @@ void WebsocketBridge::callback_Ipc_ServiceResponsesReceived(
 
   WsServiceResponse ws_server_response;
   if (!convertIpcRawServiceResponseToWsServiceResponse(service_id, call_id, response, ws_server_response)) {
-    auto msg = "[WS Bridge] - Failed to convert IPC service response to WS service response for service";
+    const auto* msg =
+        "[WS Bridge] - Failed to convert IPC service response to WS service response for service";
     heph::log(heph::ERROR, msg, "service_name", service_name, "service_id", service_id, "call_id", call_id,
               "service_name", service_name);
     ws_server_->sendServiceFailure(client_handle, service_id, call_id, msg);

--- a/modules/websocket_bridge/src/websocket_bridge/bridge.cpp
+++ b/modules/websocket_bridge/src/websocket_bridge/bridge.cpp
@@ -210,17 +210,15 @@ void WebsocketBridge::stop() {
 void WebsocketBridge::callback_IpcGraph_TopicFound(const std::string& topic,
                                                    const heph::serdes::TypeInfo& type_info) {
   CHECK(ipc_graph_);
-  heph::log(heph::INFO, "[WS Bridge] - New topic will be added  ...", "topic", topic, "type_name",
+  heph::log(heph::DEBUG, "[WS Bridge] - New topic will be added  ...", "topic", topic, "type_name",
             type_info.name);
 
   if (state_.hasIpcTopicMapping(topic)) {
     if (config_.ws_server_verbose_bridge_state) {
       state_.printBridgeState();
     }
-    heph::log(
-        heph::WARN,
-        fmt::format("\n[WS Bridge] - Topic is already advertized! There are likely multiple publishers!",
-                    "topic", topic));
+    heph::log(heph::WARN, "[WS Bridge] - Topic is already advertised! There are likely multiple publishers!",
+              "topic", topic);
     return;
   }
 
@@ -238,15 +236,13 @@ void WebsocketBridge::callback_IpcGraph_TopicFound(const std::string& topic,
 }
 
 void WebsocketBridge::callback_IpcGraph_TopicDropped(const std::string& topic) {
-  heph::log(heph::INFO, "[WS Bridge] - Topic will be dropped  ...", "topic", topic);
+  heph::log(heph::DEBUG, "[WS Bridge] - Topic will be dropped  ...", "topic", topic);
   if (!state_.hasIpcTopicMapping(topic)) {
     if (config_.ws_server_verbose_bridge_state) {
       state_.printBridgeState();
     }
-    heph::log(
-        heph::WARN,
-        fmt::format("\n[WS Bridge] - Topic is already unadvertized! There are likely multiple publishers!",
-                    "topic", topic));
+    heph::log(heph::WARN, "[WS Bridge] - Topic is already dropped! There are likely multiple publishers!",
+              "topic", topic);
     return;
   }
 
@@ -272,7 +268,7 @@ void WebsocketBridge::callback_IpcGraph_TopicDropped(const std::string& topic) {
 
 void WebsocketBridge::callback_IpcGraph_ServiceFound(const std::string& service_name,
                                                      const heph::serdes::ServiceTypeInfo& type_info) {
-  heph::log(heph::INFO, "[WS Bridge] - Service will be added  ...", "service_name", service_name,
+  heph::log(heph::DEBUG, "[WS Bridge] - Service will be added  ...", "service_name", service_name,
             "request_type_name", type_info.request.name, "reply_type_name", type_info.reply.name);
 
   const WsServiceInfo new_ws_server_service = {
@@ -310,17 +306,15 @@ void WebsocketBridge::callback_IpcGraph_ServiceFound(const std::string& service_
 }
 
 void WebsocketBridge::callback_IpcGraph_ServiceDropped(const std::string& service_name) {
-  heph::log(heph::INFO, "[WS Bridge] - Service will be dropped  ...", "service_name", service_name);
+  heph::log(heph::DEBUG, "[WS Bridge] - Service will be dropped  ...", "service_name", service_name);
 
   if (!state_.hasIpcServiceMapping(service_name)) {
     if (config_.ws_server_verbose_bridge_state) {
       state_.printBridgeState();
     }
-    heph::log(
-        heph::WARN,
-        fmt::format(
-            "\n[WS Bridge] - Service is already unadvertized! There are likely multiple service servers!",
-            "service_name", service_name));
+    heph::log(heph::WARN,
+              "[WS Bridge] - Service is already dropped! There are likely multiple service servers!",
+              "service_name", service_name);
     return;
   }
 
@@ -451,7 +445,7 @@ void WebsocketBridge::callback_Ipc_ServiceResponsesReceived(
     const auto client_handle_w_name_lookup = state_.getClientForCallId(call_id);
     if (!client_handle_w_name_lookup.has_value()) {
       heph::log(heph::ERROR,
-                "\n[WS Bridge] - No client handle found for service call id. Dropping service respose.",
+                "[WS Bridge] - No client handle found for service call id. Dropping service respose.",
                 "call_id", call_id, "service_id", service_id);
       return;
     }
@@ -463,9 +457,8 @@ void WebsocketBridge::callback_Ipc_ServiceResponsesReceived(
   const auto client_handle = client_handle_w_name.first;
 
   if (responses.empty()) {
-    auto msg = fmt::format("\n[WS Bridge] - Timeout - no service responses received.", "service_name",
-                           service_name, "service_id", service_id);
-    heph::log(heph::ERROR, msg, "service_id", service_id, "call_id", call_id);
+    auto msg = "[WS Bridge] - Timeout - no service responses received.";
+    heph::log(heph::ERROR, msg, "service_name", service_name, "service_id", service_id, "call_id", call_id);
     ws_server_->sendServiceFailure(client_handle, service_id, call_id, msg);
     return;
   }
@@ -477,22 +470,18 @@ void WebsocketBridge::callback_Ipc_ServiceResponsesReceived(
 
   const auto& response = responses.front();
   if (response.topic != service_name) {
-    auto msg = fmt::format("\n[WS Bridge] - Response and request names do not "
-                           "match!",
-                           "service_name_in_response", response.topic, "service_name", service_name);
-
+    auto msg = "[WS Bridge] - Response and request names do not match!";
     heph::log(heph::ERROR, msg, "service_id", service_id, "call_id", call_id, "response_topic",
-              response.topic, "service_name", service_name);
+              response.topic, "service_name", service_name, "service_name_in_response", response.topic);
     ws_server_->sendServiceFailure(client_handle, service_id, call_id, msg);
     return;
   }
 
   WsServiceResponse ws_server_response;
   if (!convertIpcRawServiceResponseToWsServiceResponse(service_id, call_id, response, ws_server_response)) {
-    auto msg = fmt::format("\n[WS Bridge] - Failed to convert IPC service response "
-                           "to WS service response for service",
-                           "service_name", service_name, "service_id", service_id);
-    heph::log(heph::ERROR, msg, "service_id", service_id, "call_id", call_id, "service_name", service_name);
+    auto msg = "[WS Bridge] - Failed to convert IPC service response to WS service response for service";
+    heph::log(heph::ERROR, msg, "service_name", service_name, "service_id", service_id, "call_id", call_id,
+              "service_name", service_name);
     ws_server_->sendServiceFailure(client_handle, service_id, call_id, msg);
     return;
   }
@@ -511,19 +500,19 @@ void WebsocketBridge::callback_Ipc_ServiceResponsesReceived(
 void WebsocketBridge::callback_Ws_Log(WsLogLevel level, char const* msg) {
   switch (level) {
     case WsLogLevel::Debug:
-      heph::log(heph::DEBUG, fmt::format("\n[WS Server] - {}", msg));
+      heph::log(heph::DEBUG, fmt::format("[WS Server] - {}", msg));
       break;
     case WsLogLevel::Info:
-      heph::log(heph::INFO, fmt::format("\n[WS Server] - {}", msg));
+      heph::log(heph::INFO, fmt::format("[WS Server] - {}", msg));
       break;
     case WsLogLevel::Warn:
-      heph::log(heph::WARN, fmt::format("\n[WS Server] - {}", msg));
+      heph::log(heph::WARN, fmt::format("[WS Server] - {}", msg));
       break;
     case WsLogLevel::Error:
-      heph::log(heph::ERROR, fmt::format("\n[WS Server] - {}", msg));
+      heph::log(heph::ERROR, fmt::format("[WS Server] - {}", msg));
       break;
     case WsLogLevel::Critical:
-      heph::log(heph::FATAL, fmt::format("\n[WS Server] - {}", msg));
+      heph::log(heph::FATAL, fmt::format("[WS Server] - {}", msg));
       break;
   }
 }
@@ -587,13 +576,11 @@ void WebsocketBridge::callback_Ws_Unsubscribe(WsChannelId channel_id, const WsCl
       heph::log(heph::INFO, "[WS Bridge] - Client unsubscribed from topic successfully. [IPC SUB REMOVED]",
                 "client_name", client_name, "topic", topic, "channel_id", channel_id);
     } else {
-      heph::log(heph::INFO,
-                "\n[WS Bridge] - Client unsubscribed from topic successfully. [IPC SUB NOT FOUND]",
+      heph::log(heph::INFO, "[WS Bridge] - Client unsubscribed from topic successfully. [IPC SUB NOT FOUND]",
                 "client_name", client_name, "topic", topic, "channel_id", channel_id);
     }
   } else {
-    heph::log(heph::INFO,
-              "\n[WS Bridge] - Client unsubscribed from topic successfully. [IPC SUB STILL NEEDED]",
+    heph::log(heph::INFO, "[WS Bridge] - Client unsubscribed from topic successfully. [IPC SUB STILL NEEDED]",
               "client_name", client_name, "topic", topic, "channel_id", channel_id);
   }
   if (config_.ws_server_verbose_bridge_state) {
@@ -670,10 +657,9 @@ void WebsocketBridge::callback_Ws_ClientUnadvertise(WsClientChannelId client_cha
   auto client_handle_with_name = state_.getClientForClientChannel(client_channel_id);
 
   if (!client_handle_with_name.has_value()) {
-    heph::log(
-        heph::ERROR,
-        "\n[WS Bridge] - Client tried to unadvertise topic but the channel is not owned by this client!",
-        "client_name", client_name, "channel_id", client_channel_id, "topic", topic);
+    heph::log(heph::ERROR,
+              "[WS Bridge] - Client tried to unadvertise topic but the channel is not owned by this client!",
+              "client_name", client_name, "channel_id", client_channel_id, "topic", topic);
     return;
   }
 
@@ -683,14 +669,14 @@ void WebsocketBridge::callback_Ws_ClientUnadvertise(WsClientChannelId client_cha
   if (!state_.hasClientChannelsForTopic(topic)) {
     if (ipc_entity_manager_->hasPublisher(topic)) {
       ipc_entity_manager_->removePublisher(topic);
-      heph::log(heph::INFO, "[WS Bridge] - Client unadvertised topic successfully. [IPC PUB REMOVED]",
+      heph::log(heph::INFO, "[WS Bridge] - Client dropped topic successfully. [IPC PUB REMOVED]",
                 "client_name", client_name, "topic", topic, "client_channel_id", client_channel_id);
     } else {
-      heph::log(heph::INFO, "[WS Bridge] - Client unadvertised topic successfully. [IPC PUB NOT FOUND]",
+      heph::log(heph::INFO, "[WS Bridge] - Client dropped topic successfully. [IPC PUB NOT FOUND]",
                 "client_name", client_name, "topic", topic, "client_channel_id", client_channel_id);
     }
   } else {
-    heph::log(heph::INFO, "[WS Bridge] - Client unadvertised topic successfully. [IPC PUB STILL NEEDED]",
+    heph::log(heph::INFO, "[WS Bridge] - Client dropped topic successfully. [IPC PUB STILL NEEDED]",
               "client_name", client_name, "topic", topic, "client_channel_id", client_channel_id);
   }
 
@@ -706,8 +692,8 @@ void WebsocketBridge::callback_Ws_ClientMessage(const WsClientMessage& message,
   const auto& channel_id = message.advertisement.channelId;
 
   if (!ipc_entity_manager_->hasPublisher(topic)) {
-    heph::log(heph::ERROR, "[WS Bridge] - Client sent message for unadvertised topic!", "client_name",
-              client_name, "topic", topic);
+    heph::log(heph::ERROR, "[WS Bridge] - Client sent message for dropped topic!", "client_name", client_name,
+              "topic", topic);
     return;
   }
 
@@ -760,9 +746,8 @@ void WebsocketBridge::callback_Ws_ServiceRequest(const WsServiceRequest& request
   const std::string client_name = ws_server_->remoteEndpointString(client_handle);
 
   if (!state_.hasWsServiceMapping(request.serviceId)) {
-    auto msg =
-        fmt::format("\n[WS Bridge] - Client '{}' sent service request for unadvertised service [{}/{}]!",
-                    client_name, request.serviceId, request.callId);
+    auto msg = fmt::format("[WS Bridge] - Client '{}' sent service request for dropped service [{}/{}]!",
+                           client_name, request.serviceId, request.callId);
     heph::log(heph::ERROR, msg, "service_id", request.serviceId, "call_id", request.callId, "client_name",
               client_name);
     ws_server_->sendServiceFailure(client_handle, request.serviceId, request.callId, msg);
@@ -770,7 +755,7 @@ void WebsocketBridge::callback_Ws_ServiceRequest(const WsServiceRequest& request
   }
 
   if (request.encoding != "protobuf") {
-    auto msg = fmt::format("\n[WS Bridge] - Client '{}' sent service request [{}/{}] with unsuported "
+    auto msg = fmt::format("[WS Bridge] - Client '{}' sent service request [{}/{}] with unsuported "
                            "encoding ({})!",
                            client_name, request.serviceId, request.callId, request.encoding);
     heph::log(heph::ERROR, msg, "service_id", request.serviceId, "call_id", request.callId, "client_name",

--- a/modules/websocket_bridge/src/websocket_bridge/ipc/ipc_entity_manager.cpp
+++ b/modules/websocket_bridge/src/websocket_bridge/ipc/ipc_entity_manager.cpp
@@ -111,7 +111,7 @@ void IpcEntityManager::addSubscriber(const std::string& topic, const serdes::Typ
       session_, ipc::TopicConfig{ topic },
       // NOLINTNEXTLINE(bugprone-exception-escape)
       [subscriber_cb, type_info = topic_type_info](const ipc::zenoh::MessageMetadata& metadata,
-                                       std::span<const std::byte> data) {
+                                                   std::span<const std::byte> data) {
         subscriber_cb(metadata, data, type_info);
       },
       topic_type_info, subscriber_config);

--- a/modules/websocket_bridge/src/websocket_bridge/ipc/ipc_entity_manager.cpp
+++ b/modules/websocket_bridge/src/websocket_bridge/ipc/ipc_entity_manager.cpp
@@ -110,9 +110,9 @@ void IpcEntityManager::addSubscriber(const std::string& topic, const serdes::Typ
   subscribers_[topic] = std::make_unique<ipc::zenoh::RawSubscriber>(
       session_, ipc::TopicConfig{ topic },
       // NOLINTNEXTLINE(bugprone-exception-escape)
-      [subscriber_cb, topic_type_info](const ipc::zenoh::MessageMetadata& metadata,
+      [subscriber_cb, type_info = topic_type_info](const ipc::zenoh::MessageMetadata& metadata,
                                        std::span<const std::byte> data) {
-        subscriber_cb(metadata, data, topic_type_info);
+        subscriber_cb(metadata, data, type_info);
       },
       topic_type_info, subscriber_config);
 }

--- a/modules/websocket_bridge/src/websocket_bridge/utils/ws_protocol.cpp
+++ b/modules/websocket_bridge/src/websocket_bridge/utils/ws_protocol.cpp
@@ -27,10 +27,6 @@ auto convertIpcRawServiceResponseToWsServiceResponse(
     WsServiceId service_id, WsServiceCallId call_id,
     const ipc::zenoh::ServiceResponse<std::vector<std::byte>>& raw_response, WsServiceResponse& ws_response)
     -> bool {
-  if (raw_response.value.empty()) {
-    return false;
-  }
-
   std::vector<uint8_t> response_data(raw_response.value.size());
   std::ranges::transform(raw_response.value, response_data.begin(),
                          [](std::byte b) { return static_cast<uint8_t>(b); });


### PR DESCRIPTION
# Description

Various bugfixes and improvements

General (pushing them upstream here: https://github.com/olympus-robotics/hephaestus/pull/367)
 - dynamic subscriber - advertised type service call of that subscriber was broken
  - fix accidental type service recursion (i.e. type services of raw subs/pubs, spawned their own type services again)
 - enable liveliness token `history` subscriber option -> Should (**but currently doesn't**) allow for late-joiners to discovery all topics/services
 - websocket bridge
    - websocket bridge didn't forward empty (but valid) service responses
    - generally lower default verbosity of websocket bridge and add option for verbose output
    - actually implement whitelisting/blacklisting of topics/services
 
 
 Voliro specific
 - fix log level verbosity issue

## Type of change
- Bug fix (non-breaking change which fixes an issue)